### PR TITLE
excluding lstdc++fs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 CXXFLAGS = -Wall -Wextra -std=c++17 -O3
 OBJS = globals.o print.o variant.o dist.o bed.o cluster.o phase.o edit.o timer.o
 TARGET = vcfdist
-LDLIBS = -lz -lhts -lstdc++fs -lpthread
+LDLIBS = -lz -lhts -lpthread
 
 all: $(TARGET)
 


### PR DESCRIPTION
It is unnecessary this library because it is installed as part of the standard package. I had a bad time trying to compile it as is in my system (ARM64). If it is necessary for other systems, or versions, please feel free to delete this commit. Thanks for your amazing work.