### PR TITLE
Fix errtype/err type inconsistency

### DIFF
--- a/docs/dev/09-Outputs.md
+++ b/docs/dev/09-Outputs.md
@@ -41,7 +41,7 @@ Reports detailed information regarding each variant.
 | ALT | string | Alternate allele of this variant. |
 | QUAL | float | Quality score of this variant. |
 | TYPE | categorical | Type of variant (REF/SNP/INS/DEL/CPX). |
-| ERR_TYPE | categorical | Classification error type (TP/FP/FN). |
+| ERRTYPE | categorical | Classification error type (TP/FP/FN). |
 | CREDIT | float | Fraction of partial credit (in terms of correctness) that this variant received. --credit-threshold determines whether it is a true or false positive. |
 | CLUSTER | integer | 0-based index of the cluster on the current haplotype of this contig containing this variant. |
 | SUPERCLUSTER | integer | 0-based index of the supercluster on this contig containing this variant. |

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -674,7 +674,7 @@ void write_results(std::unique_ptr<phaseblockData> & phasedata_ptr) {
         std::string out_query_fn = g.out_prefix + "query.tsv";
         if (g.verbosity >= 1) INFO("  Writing query variant results to '%s'", out_query_fn.data());
         FILE* out_query = fopen(out_query_fn.data(), "w");
-        fprintf(out_query, "CONTIG\tPOS\tHAP\tREF\tALT\tQUAL\tTYPE\tERR_TYPE"
+        fprintf(out_query, "CONTIG\tPOS\tHAP\tREF\tALT\tQUAL\tTYPE\tERRTYPE"
                 "\tCREDIT\tCLUSTER\tSUPERCLUSTER\tSYNC_GROUP\tREF_DIST\tQUERY_DIST\tLOCATION\n");
         for (std::string ctg : phasedata_ptr->contigs) {
 


### PR DESCRIPTION
Hi there,

Another minor bug (v. minor?) fix. Right now, query.tsv output files use the column header ERR_TYPE for the tsv column containing TP/FP/FN annotations, and truth.tsv files use ERRTYPE. That makes downstream analysis difficult, since you have to change that column name if you want to merge these two datasets in any way.

ERR_TYPE is only used when writing query.tsv or in the Outputs.md wiki page. All other references to those data (variable names, etc) use ERRTYPE. So, this pull request changes those two instances of "ERR_TYPE" to ERRTYPE, unifying the naming conventions and easing downstream analysis.

Hope this is helpful,
Joe