### PR TITLE
fix(variant): always set ac_errtype in set_allele_errtype

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -192,7 +192,7 @@ int ctgVariants::set_allele_errtype(int vi) {
             return this->ac_errtype[vi] = AC_ERR_0_TO_1;
         }
     }
-    return AC_UNKNOWN;
+    return this->ac_errtype[vi] = AC_UNKNOWN;
 }
 
 


### PR DESCRIPTION
## Root cause

`ctgVariants::set_allele_errtype(int vi)` in `src/variant.cpp` classifies the allele-count error type by comparing `calc_gts[vi]` and `orig_gts[vi]`, assigning the result to `this->ac_errtype[vi]` in every handled branch. However, the fall-through path (e.g. `calc_gts[vi] == GT_REF_REF` with `orig_gts[vi] == GT_REF_REF`, and any other combination matching no inner branch) executed `return AC_UNKNOWN;` **without** assigning `this->ac_errtype[vi]`. This left a stale value in `ac_errtype[vi]` while returning `AC_UNKNOWN`, so the stored value and the returned value could disagree.

## Fix

Minimal, one-line change: the fall-through/return path now assigns before returning:

```cpp
return this->ac_errtype[vi] = AC_UNKNOWN;
```

This guarantees `this->ac_errtype[vi]` is always written and agrees with the return value in every case. The classification logic of the handled cases is unchanged.

## Compile verification

```
cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 variant.cpp -o /tmp/probe_59.o
```

Exit 0, clean — no new warnings or errors.

---

Sub-issue of #45; documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #1.

Fixes #59