### PR TITLE
fix(variant): guard add_variants against unknown CIGAR op

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -578,6 +578,7 @@ void variantData::print_variant(FILE* out_fp, const std::string & ctg, int pos, 
  * @param[in] ref Reference sequence
  * @param[in] qual Quality score for all variants
  * @param[in] phase_set Phase set identifier for all variants
+ * @throws ERROR Unexpected CIGAR/pointer operation not in {PTR_MAT, PTR_SUB, PTR_DEL, PTR_INS}
  */
 void variantData::add_variants(
         const std::vector<int> & cigar,
@@ -636,6 +637,9 @@ void variantData::add_variants(
                         GT_REF_REF, g.max_qual, qual, phase_set);
                 query_idx += indel_len;
                 break;
+
+            default:
+                ERROR("Unexpected CIGAR operation (%d) in add_variants", cigar[cig_idx]);
         }
     }
 }


### PR DESCRIPTION
## Root cause

`variantData::add_variants` iterates a CIGAR/pointer vector with a `switch` over `PTR_MAT`/`PTR_SUB`/`PTR_DEL`/`PTR_INS` inside a `while` loop, where `cig_idx` is advanced only from within the matched case. An unrecognized op matched no case, so `cig_idx` never advanced and the loop spun forever — a malformed input hung the process instead of failing.

## Fix

Added a `default:` case that calls `ERROR(...)` (which exits) naming the unexpected op value, matching the existing `ERROR()` usage style in the file. This makes malformed input fail fast. Updated the function's Doxygen comment with a `@throws ERROR ...` line per repo conventions.

## Compile result

`g++ -c -g -O1 -Wall -Wextra -std=c++17 variant.cpp` — clean, no warnings.

Fixes #60
Sub-issue of #45 (documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #2).