### PR TITLE
fix(dist): guard empty inputs in wf_swg_align

### DIFF
--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -604,6 +604,15 @@ void wf_swg_align(
     // init
     int query_len = query.size();
     int truth_len = truth.size();
+
+    // early exit if either string is empty, else mat_len underflows and the
+    // wavefront indexes out of range. An empty string turns the whole alignment
+    // into a single gap over the other string, costing o + e per base (gap open
+    // once, gap extend per base).
+    if (!query_len && !truth_len) { s = 0; return; }
+    if (!query_len) { s = o + e*truth_len; return; }
+    if (!truth_len) { s = o + e*query_len; return; }
+
     int mat_len = query_len + truth_len - 1;
     bool done = false;
     std::vector< std::vector< std::vector<int> > > offs(MATS);

--- a/src/dist.cpp
+++ b/src/dist.cpp
@@ -605,10 +605,7 @@ void wf_swg_align(
     int query_len = query.size();
     int truth_len = truth.size();
 
-    // early exit if either string is empty, else mat_len underflows and the
-    // wavefront indexes out of range. An empty string turns the whole alignment
-    // into a single gap over the other string, costing o + e per base (gap open
-    // once, gap extend per base).
+    // early exit if either string is empty
     if (!query_len && !truth_len) { s = 0; return; }
     if (!query_len) { s = o + e*truth_len; return; }
     if (!truth_len) { s = o + e*query_len; return; }


### PR DESCRIPTION
## Root cause

`wf_swg_align(...)` in `src/dist.cpp` had no empty-string guard (unlike `wf_ed`, which guards at its top). With an empty `query` or `truth`:

- `mat_len = query_len + truth_len - 1` underflows to `-1` when both are empty, and
- the immediate `offs[MAT_SUB][s][query_len-1] = -1` (and subsequent wavefront indexing) go out of range when `query_len == 0`.

This is an out-of-bounds indexing defect (latent, since callers currently pass non-empty strings).

## Fix

Added an early guard mirroring `wf_ed`, placed after computing `query_len`/`truth_len` and before `mat_len`:

```cpp
if (!query_len && !truth_len) { s = 0; return; }
if (!query_len) { s = o + e*truth_len; return; }
if (!truth_len) { s = o + e*query_len; return; }
```

### Cost convention

An empty string reduces the alignment to a single gap spanning the entire other string. The function's gap-affine convention (read from its own transitions) is: opening a gap costs `o + e` (transition `s-(o+e)` for the first base), and each additional base extends at `s - e`. So a gap of length `L` costs `o + e*L` — gap-open once plus gap-extend per base. Hence inserting all of `truth` costs `o + e*truth_len`, deleting all of `query` costs `o + e*query_len`, and two empty strings cost `0`.

Behavior for non-empty inputs is unchanged.

## Compile check

`g++ -c -g -O1 -Wall -Wextra -std=c++17 dist.cpp` is clean (the only warning, `unused parameter 'thread2'` at an unrelated line, is pre-existing).

Fixes #65
Sub-issue of #45 (documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #7).