### PR TITLE
fix(phase): use tvars->n in fix_allele_counts truth loop

### DIFF
--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -428,7 +428,7 @@ void phaseblockData::fix_allele_counts() {
         // false negative errors can only be counted from the truth VCF
         std::shared_ptr<ctgVariants> tvars = 
             this->phase_blocks[ctg]->ctg_superclusters->callset_vars[TRUTH];
-        for (int vi = 0; vi < qvars->n; vi++) {
+        for (int vi = 0; vi < tvars->n; vi++) {
             int vartype = tvars->get_vartype(vi);
             if (tvars->orig_gts[vi] == GT_ALT1_ALT1) {
                 if (tvars->errtypes[HAP1][vi] == ERRTYPE_FN && 


### PR DESCRIPTION
## Root cause

In `phaseblockData::fix_allele_counts()` (src/phase.cpp), the truth-side loop that counts truth-only FN allele errors (`AC_ERR_2_TO_0` / `AC_ERR_1_TO_0`) indexes the TRUTH container `tvars` throughout its body (`tvars->get_vartype(vi)`, `tvars->orig_gts[vi]`, `tvars->errtypes[...][vi]`) but its loop condition used the QUERY count `qvars->n`. When truth and query variant counts differ, this reads `tvars` out of range (when `qvars->n > tvars->n`) or silently skips truth variants (when `qvars->n < tvars->n`), miscounting FN allele errors.

## Fix

One-line bound correction so the loop iterates the container it indexes:

```cpp
-        for (int vi = 0; vi < qvars->n; vi++) {
+        for (int vi = 0; vi < tvars->n; vi++) {
```

The earlier query-side loop (correctly bounded by `qvars->n`) is unchanged.

## Compile result

`g++ -c -g -O1 -Wall -Wextra -std=c++17 phase.cpp` — clean (exit 0, no warnings).

Fixes #67

Sub-issue of #45; documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #9.