### PR TITLE
fix(phase): guard divide-by-zero in write_phasing_summary

### DIFF
--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -789,8 +789,6 @@ void phaseblockData::write_phasing_summary(int phase_blocks, int switch_errors,
     fprintf(out_phasing_summary,
             "PHASE_BLOCKS\tSWITCH_ERRORS\tFLIP_ERRORS\tSWITCH_ERROR_RATE\tFLIP_ERROR_RATE\t"
             "NG_50\tSWITCH_NGC50\tSWITCHFLIP_NGC50\n");
-    // guard against divide-by-zero: with no phased variants, report a 0 rate
-    // (the phase() console path skips these rate lines entirely when variants == 0)
     float switch_error_rate = variants ? 100*switch_errors/float(variants) : 0;
     float flip_error_rate = variants ? 100*flip_errors/float(variants) : 0;
     fprintf(out_phasing_summary, "%d\t%d\t%d\t%.6f%%\t%.6f%%\t%d\t%d\t%d", phase_blocks,

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -789,9 +789,13 @@ void phaseblockData::write_phasing_summary(int phase_blocks, int switch_errors,
     fprintf(out_phasing_summary,
             "PHASE_BLOCKS\tSWITCH_ERRORS\tFLIP_ERRORS\tSWITCH_ERROR_RATE\tFLIP_ERROR_RATE\t"
             "NG_50\tSWITCH_NGC50\tSWITCHFLIP_NGC50\n");
-    fprintf(out_phasing_summary, "%d\t%d\t%d\t%.6f%%\t%.6f%%\t%d\t%d\t%d", phase_blocks, 
-            switch_errors, flip_errors, 100*switch_errors/float(variants),
-            100*flip_errors/float(variants), ng50, s_ngc50, sf_ngc50);
+    // guard against divide-by-zero: with no phased variants, report a 0 rate
+    // (the phase() console path skips these rate lines entirely when variants == 0)
+    float switch_error_rate = variants ? 100*switch_errors/float(variants) : 0;
+    float flip_error_rate = variants ? 100*flip_errors/float(variants) : 0;
+    fprintf(out_phasing_summary, "%d\t%d\t%d\t%.6f%%\t%.6f%%\t%d\t%d\t%d", phase_blocks,
+            switch_errors, flip_errors, switch_error_rate,
+            flip_error_rate, ng50, s_ngc50, sf_ngc50);
     fclose(out_phasing_summary);
 }
 


### PR DESCRIPTION
## Root cause

`phaseblockData::write_phasing_summary()` in `src/phase.cpp` computed the switch- and flip-error rate columns as `100 * errors / float(variants)` with no guard. When `variants == 0` (no phased query variants), this yields `nan`/`inf` in the `SWITCH_ERROR_RATE` and `FLIP_ERROR_RATE` columns of `phasing-summary.tsv`. The `phase()` console path already guards this by skipping the rate lines when `variants == 0`; the file writer did not.

## Fix

Guard the two divisions so that `variants == 0` yields a rate of `0`:

```cpp
float switch_error_rate = variants ? 100*switch_errors/float(variants) : 0;
float flip_error_rate   = variants ? 100*flip_errors/float(variants) : 0;
```

## Zero-value convention

The console path in `phase()` prints the rate lines only when `variants` is nonzero, so there is no explicit console sentinel. This writer emits `0.000000%` for the zero-variant case (a defined, finite value) and is byte-identical to the previous output whenever `variants > 0`.

## Compile

`g++ -c -g -O1 -Wall -Wextra -std=c++17 phase.cpp` — clean (exit 0, no warnings).

Fixes #68
Sub-issue of #45 (D2 §6 defect #10).