### PR TITLE
fix(cluster): make get_min_ref_pos empty-range sentinel consistent (#62)

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -35,10 +35,14 @@ ctgSuperclusters::ctgSuperclusters() {
  */
 int ctgSuperclusters::get_min_ref_pos(int qvi_start, int qvi_end, int tvi_start, int tvi_end) {
     // NOTE: qvi_start == qvi_end == vars->n is valid (empty sentinel), should return int::max
-    return std::min( (qvi_start == qvi_end) ? std::numeric_limits<int>::max() : 
-                this->callset_vars[QUERY]->poss[qvi_start], 
+    int min_ref_pos = std::min(
+            (qvi_start == qvi_end) ? std::numeric_limits<int>::max() :
+                this->callset_vars[QUERY]->poss[qvi_start],
             (tvi_start == tvi_end) ? std::numeric_limits<int>::max() :
-                this->callset_vars[TRUTH]->poss[tvi_start]) - 1;
+                this->callset_vars[TRUTH]->poss[tvi_start]);
+    // apply the -1 padding only to real positions, so the empty-range sentinel stays int::max()
+    // and is consistent with get_max_ref_pos (previously this returned int::max()-1)
+    return (min_ref_pos == std::numeric_limits<int>::max()) ? min_ref_pos : min_ref_pos - 1;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a latent asymmetry in the empty-range sentinels of `ctgSuperclusters::get_min_ref_pos` / `get_max_ref_pos` in `src/cluster.cpp`.

- `get_max_ref_pos` returns `INT_MAX` on an empty range (both query and truth intervals empty).
- `get_min_ref_pos` returned `INT_MAX - 1` on an empty range, because the trailing `- 1` padding was applied unconditionally — including to the `INT_MAX` empty sentinel.

Both functions document their empty-range return as `int::max()` (see the `@return` docs and the inline `NOTE: ... should return int::max` on each). So the `INT_MAX - 1` result was a plain oversight: the `- 1` padding, which is meant to widen the reference window by one base for *real* positions, was accidentally also shifting the sentinel.

## Caller analysis

The only caller of either function is `Graph::Graph` (`src/dist.cpp:894-895`):

```cpp
int ref_beg = sc->get_min_ref_pos(qvar_beg, qvar_end, tvar_beg, tvar_end);
int ref_end = sc->get_max_ref_pos(qvar_beg, qvar_end, tvar_beg, tvar_end);
```

`ref_beg`/`ref_end` bound the reference window for the alignment graph. The returned value is used as a position, subtracted from other positions (`x - ref_beg`), and used as a loop bound (`ref_pos < var_pos`) — it is never itself compared against the other sentinel. The both-empty case is not reachable here in practice (a supercluster always contains at least one variant), which is why this is a **latent** defect.

Because:
1. the both-empty sentinel case is unreachable from the sole caller, and
2. for every non-empty range the returned value is unchanged (padding still applied to real positions),

aligning `get_min_ref_pos`'s empty sentinel to `INT_MAX` cannot change any existing behavior.

## Decision: align (not document-and-preserve)

The documented intent for both functions is `int::max()` on empty, and `get_max_ref_pos` already honors that. So I aligned `get_min_ref_pos` to match rather than merely documenting the asymmetry: I guarded the `- 1` padding so it applies only to real positions, leaving the empty sentinel as `INT_MAX`. Non-empty behavior is byte-for-byte identical.

## Verification

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 cluster.cpp -o /tmp/probe_62.o` — clean, no warnings.

## Scope

Change is strictly within `get_min_ref_pos`; `get_max_ref_pos` is unchanged. No other issues touched (aware #63/#64 touch other functions in `cluster.cpp` in parallel).

Fixes #62. Sub-issue of #45; documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #4.

@maintainer — flagging for review, since this is a judgment call on a latent (currently-unreachable) sentinel; please confirm `INT_MAX` is the preferred empty-range convention over `INT_MAX - 1`.