### PR TITLE
fix(dist): make idx4::operator< a strict weak ordering

### DIFF
--- a/src/dist.h
+++ b/src/dist.h
@@ -98,11 +98,10 @@ public:
      * @return True if this cell precedes other in (qni, tni, qi, ti) order
      */
     bool operator<(const idx4 & other) const {
-        if (this->qni < other.qni) return true;
-        if (this->tni < other.tni) return true;
-        if (this->qi < other.qi) return true;
-        if (this->ti < other.ti) return true;
-        return false;
+        if (this->qni != other.qni) return this->qni < other.qni;
+        if (this->tni != other.tni) return this->tni < other.tni;
+        if (this->qi  != other.qi)  return this->qi  < other.qi;
+        return this->ti < other.ti;
     }
 
     /**


### PR DESCRIPTION
## Root cause

`idx4::operator<` in `src/dist.h` was not a strict weak ordering. It returned `true` as soon as any single field compared `<`, without first requiring the higher-priority fields to be equal:

```cpp
if (this->qni < other.qni) return true;
if (this->tni < other.tni) return true;
if (this->qi  < other.qi)  return true;
if (this->ti  < other.ti)  return true;
return false;
```

This violates antisymmetry/transitivity: e.g. `a = {0,5,0,0}` and `b = {1,0,0,0}` yield both `a < b` (qni 0<1) and `b < a` (tni 0<5) true, so the relation is inconsistent. Using it in any ordered container (`std::map`, `std::set`, `std::sort`) would be undefined behavior.

## Fix

Corrected to a proper lexicographic comparison over `(qni, tni, qi, ti)` using the standard cascaded form:

```cpp
if (this->qni != other.qni) return this->qni < other.qni;
if (this->tni != other.tni) return this->tni < other.tni;
if (this->qi  != other.qi)  return this->qi  < other.qi;
return this->ti < other.ti;
```

Field order and all other members are unchanged.

## Compile result

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 dist.cpp -o /tmp/probe_66.o` compiles clean. (The only warning is a pre-existing `unused parameter 'thread2'` at dist.cpp:1064, unrelated to this change.)

## Impact

`idx4` is currently only used in unordered containers (`std::unordered_set`/`std::unordered_map`, which key off `operator==`/hash, not `operator<`), so this is a latent/correctness fix rather than an active bug — it hardens the type against future use in ordered containers.

Fixes #66
Sub-issue of #45 (documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #8).