### PR TITLE
fix(cluster): guard div-by-zero in get_supercluster_split_location (#63)

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1186,13 +1186,26 @@ std::vector<int> get_supercluster_split_location(
     while (next_var.callset_idx >= 0) {
 
         // calculate max split size reduction factor
+        // best case: it splits the supercluster exactly in half (0.5)
+        // worst case: it splits at the end, supercluster is same size (1.0)
         int gap = std::max(0, next_var.start_pos - curr_var.end_pos);
-        double size_reduction_factor = std::max(double((curr_var.end_pos + gap/2) - orig_sc_beg_pos) / orig_sc_size,
+        double size_reduction_factor = orig_sc_size == 0 ? 1.0 :
+            std::max(double((curr_var.end_pos + gap/2) - orig_sc_beg_pos) / orig_sc_size,
                 double(orig_sc_end_pos - (curr_var.end_pos + gap/2)) / orig_sc_size);
-        double splits_to_halve_size = -1 / log2(size_reduction_factor);
 
-        // calculate overlap (could weight by number of haps overlapping)
-        double split_score = gap / splits_to_halve_size;
+        // log2_srf ranges from -1 (best) to 0 (worst)
+        double log2_srf = log2(size_reduction_factor);
+        double splits_to_halve_size = 0;
+        double split_score = 0;
+        if (size_reduction_factor > 0 && size_reduction_factor < 1.0 && log2_srf != 0) {
+            // ranges from 1 (best) to inf (worst)
+            splits_to_halve_size = -1 / log2_srf;
+
+            // Idea 1: split supercluster at largest gap
+            // Idea 2: split as close to middle as possible
+            // Final score: weigh both of these factors
+            split_score = gap / splits_to_halve_size;
+        }
         if (print) printf("indices: [%d, %d], gap: %d, frac: %f, splits: %f, score: %f\n",
                 split_indices[0], split_indices[1], gap, size_reduction_factor, splits_to_halve_size, split_score);
         if (split_score > best_split_score) {


### PR DESCRIPTION
## Root cause

In `get_supercluster_split_location` (`src/cluster.cpp`), each candidate split point is scored as:

```cpp
double splits_to_halve_size = -1 / log2(size_reduction_factor);
double split_score = gap / splits_to_halve_size;
```

`size_reduction_factor` is `max(left_fraction, right_fraction)` of the supercluster range, so it lies in `[0.5, 1.0]`. When a candidate split sits at a supercluster edge, the factor is exactly `1.0`, and `log2(1.0) == 0` makes `-1 / 0` a division by zero (produces `-inf`); the subsequent `gap / -inf` yields `-0.0`. In addition, a zero-width supercluster (`orig_sc_size == 0`, e.g. all variants at one position) makes the two fraction divisions `inf`/`nan`, which then poison the log2 and the score.

## The guard

Scoped strictly to `get_supercluster_split_location`:

- `size_reduction_factor` is set to `1.0` up front when `orig_sc_size == 0`, avoiding the `inf`/`nan` fraction divisions.
- The `splits_to_halve_size` / `split_score` computation now runs only when the denominator is well-defined: `size_reduction_factor` in `(0, 1)` and `log2 != 0`. Otherwise `split_score` defaults to `0`.

Because `best_split_score` starts at `0` and selection uses a strict `>` comparison, a degenerate candidate scored `0` is simply never selected — so **scoring behavior for all normal (interior) candidates is byte-for-byte identical**. The only change is that edge / zero-width candidates can no longer generate `inf`/`nan`/`-0.0`. The debug `print` output is preserved (`splits_to_halve_size` prints as `0` for skipped candidates).

## Deliberately left for maintainer decision

The related "dense region returns `{}`" symptom (a supercluster with zero inter-variant gaps scores `0` for every candidate, so `var_best_split_indices` stays empty and no split is made) is a **selection-policy** question, not a div-by-zero. Changing it would alter behavior for well-formed inputs, so per issue scope it is intentionally NOT changed here. This guard does not regress that case — it still returns `{}` — but it also no longer relies on `-0.0` arithmetic to do so.

## Verification

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 cluster.cpp -o /tmp/probe_63.o` — clean (exit 0, no warnings).

## Scope / interaction

Edits are confined to `get_supercluster_split_location`. `split_large_supercluster` (#64) and the range/sentinel helpers (#62) are untouched. #64 is being fixed in parallel and also touches `cluster.cpp`; there is no overlap with this function, but reviewers merging both should expect adjacent-region diffs in the same file.

Fixes #63
Sub-issue of #45 (documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #5).