### PR TITLE
fix(cluster): surface retained oversized supercluster in split_large_supercluster (#64)

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -997,7 +997,8 @@ std::vector<int> get_supercluster_range(
  * @param[in] cluster_start_indices The 0-based inclusive index of the first cluster on each callset.
  * @param[in] cluster_end_indices The 0-based exclusive index of the last cluster on each callset.
  * @param[in] print Boolean indicating whether debug printing is enabled.
- * @throws WARNING if there are no valid locations to split the supercluster.
+ * @throws WARNING if no valid split location is found, in which case the oversized supercluster is
+ *     retained (its size and the --max-supercluster-size limit are reported) and processing continues.
  */
 std::vector< std::vector<int> > split_large_supercluster(
         std::vector< std::shared_ptr<ctgVariants> > & vars,
@@ -1027,8 +1028,11 @@ std::vector< std::vector<int> > split_large_supercluster(
                     std::vector<int> cluster_split_indices = split_cluster(vars, best_var_split, breakpoints, i, print);
                     next_breakpoints.push_back(cluster_split_indices);
 
-                } else { // no valid splits (shouldn't happen?)
-                    printf("WARNING: no valid splits at %d-%d\n", beg_pos, end_pos);
+                } else { // no valid split location found; retain oversized supercluster
+                    WARN("No valid split location for oversized supercluster at %d-%d "
+                            "(size %d exceeds --max-supercluster-size %d); retaining "
+                            "oversized supercluster and continuing",
+                            beg_pos, end_pos, end_pos - beg_pos, g.max_supercluster_size);
                     large_supercluster_exists = false;
                 }
 


### PR DESCRIPTION
## Root cause

In `split_large_supercluster` (`src/cluster.cpp`), the `while` loop repeatedly splits any piece larger than `g.max_supercluster_size`. When `get_supercluster_split_location` returns no valid split location, the code hit an escape hatch that emitted a bare `printf("WARNING: no valid splits at %d-%d\n", ...)` and set `large_supercluster_exists = false` to force loop termination. The oversized supercluster was then returned unchanged, so downstream stages silently received a too-large cluster. The message did not go through the standard `WARN()` channel (no timestamp/coloring, printed to stdout not stderr) and did not state that an oversized supercluster was being retained, so the condition was easy to miss.

## The change

Scoped entirely to `split_large_supercluster`:
- Replaced the raw `printf` with the project's `WARN()` macro so the message is timestamped, colored, and goes to stderr like every other warning.
- Strengthened the message to make the retained-oversized case explicit: it now reports the supercluster range, its actual size, and the `--max-supercluster-size` limit, and states that the oversized supercluster is being retained and processing continues.
- Updated the function's `@throws WARNING` doc line to match the new behavior/message (full `.cpp` Doxygen form).

The normal splitting path (valid-split branch, `split_cluster`, breakpoint bookkeeping) is untouched. Behavior is otherwise unchanged.

## Why non-fatal

Per the issue and D2 §6 defect #6, an unsplittable oversized supercluster can be a legitimate runtime situation (e.g. a dense region with no valid interior split point). Aborting the whole run would be a regression for otherwise-valid inputs. The safe, non-behavior-changing improvement is to surface the condition loudly rather than mask it, leaving the operator to lower `--max-supercluster-size` or investigate if needed.

## Compile result

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 cluster.cpp -o /tmp/probe_64.o` — clean, no warnings.

## Notes

- Fixes #64
- Sub-issue of #45 (documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #6)
- Interaction with #63: that issue modifies `get_supercluster_split_location`, which this PR deliberately does not touch. This change only reacts to that function returning an empty result, so the two are complementary and should not conflict.