### PR TITLE
fix(variant): guard contig-start flanking base in print_var_info (#61)

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -446,18 +446,25 @@ void ctgVariants::set_var_calcgt_on_hap(int var_idx, int hap, bool set, bool ign
  * @param[in] ref Reference FASTA data for retrieving flanking bases for indels
  * @param[in] ctg Contig name
  * @param[in] idx Variant index in this container
+ * @throws ERROR An INS/DEL sits at the contig start (0-based pos 0), leaving no preceding base to anchor
+ * @throws ERROR The variant type is not TYPE_SUB, TYPE_INS, or TYPE_DEL
  */
 void ctgVariants::print_var_info(FILE* out_fp, std::shared_ptr<fastaData> ref,
         const std::string & ctg, int idx) {
     char ref_base;
     switch (this->types[idx]) {
     case TYPE_SUB:
-        fprintf(out_fp, "%s\t%d\t.\t%s\t%s\t.\tPASS\t.\tGT:BD:BC:RD:QD:BK:QQ:SC:SG:PS:PB:BS:VP:FE:GE", 
-                ctg.data(), this->poss[idx]+1, this->refs[idx].data(), 
+        fprintf(out_fp, "%s\t%d\t.\t%s\t%s\t.\tPASS\t.\tGT:BD:BC:RD:QD:BK:QQ:SC:SG:PS:PB:BS:VP:FE:GE",
+                ctg.data(), this->poss[idx]+1, this->refs[idx].data(),
                 this->alts[idx].data());
         break;
     case TYPE_INS:
     case TYPE_DEL:
+        // INS/DEL are left-anchored on the preceding reference base; at contig start (0-based
+        // pos 0) there is no preceding base, so guard against the out-of-bounds read of index -1
+        if (this->poss[idx] == 0)
+            ERROR("Cannot left-anchor INS/DEL at contig start (0-based pos 0) on '%s' in print_var_info",
+                    ctg.data());
         ref_base = ref->fasta.at(ctg)[this->poss[idx]-1];
         fprintf(out_fp, "%s\t%d\t.\t%s\t%s\t.\tPASS\t.\tGT:BD:BC:RD:QD:BK:QQ:SC:SG:PS:PB:BS:VP:FE:GE", ctg.data(), 
                 this->poss[idx], (ref_base + this->refs[idx]).data(), 


### PR DESCRIPTION
## Summary

Fixes a latent out-of-bounds read in `ctgVariants::print_var_info` and documents why the flanking-base indexing legitimately differs from `variantData::print_variant`.

Sub-issue of #45; corresponds to D2 §6 defect #3.

## Investigation

Both functions prepend a flanking (anchor) reference base for INS/DEL, but with **different `pos` conventions**, so their index expressions correctly differ:

- **`print_var_info(idx)`** reads `poss[idx]` directly. `poss` is the 0-based variant start (see `variant.h`). It anchors on `fasta[ctg][poss[idx]-1]` and emits VCF `POS = poss[idx]` (i.e. the 1-based coordinate of the anchor base `poss[idx]-1`).
- **`print_variant(pos, ...)`** receives a `pos` that the caller in `write_vcf` (variant.cpp lines 238-244) has **already decremented by one** for indels (`pos_hap1--` / `pos_hap2--`, "indels include previous base, adjust position"). So `pos == poss[idx]-1`. It anchors on `fasta[ctg][pos]` and emits `POS = pos+1`.

Substituting `pos = poss[idx]-1` into `print_variant` yields anchor `fasta[ctg][poss[idx]-1]` and `POS = poss[idx]` — **identical** to `print_var_info`. The `pos-1` vs `pos` mismatch is therefore **not a bug**: it is the natural consequence of the two functions receiving the variant position under different conventions (raw 0-based start vs. pre-decremented). I deliberately left both flanking indices unchanged.

## The real bug (fixed)

The one guaranteed defect is that `print_var_info` dereferences `fasta[ctg][poss[idx]-1]` unconditionally. For an INS/DEL at a contig start (`poss[idx]==0`) this reads index `-1` — an out-of-bounds access, plus it would emit an invalid `POS=0`. There is no preceding reference base to left-anchor on in that case.

Change: guard `poss[idx]==0` before the array access and raise a clear `ERROR` (consistent with the function's existing `ERROR` on unknown types; `ERROR` calls `std::exit(1)`, so there is no fall-through). This cannot regress correct output — the pre-existing behavior at `poss[idx]==0` was undefined, never a valid record.

Note: `print_variant` has the analogous boundary weakness (a `poss[idx]==0` indel decrements to `pos=-1`, then reads `fasta[ctg][-1]`), but per the issue scope this PR fixes only `print_var_info`. Flagging it here for maintainer awareness.

## Verification

`g++ -c -g -O1 -Wall -Wextra -std=c++17 variant.cpp` compiles cleanly (no warnings).

## Judgment call for reviewer

Please confirm the intended contig-start behavior. This PR chose to **error out** rather than fabricate an anchor, since a left-anchored indel at position 0 has no valid VCF representation without switching to right-anchoring (out of scope). If a graceful right-anchored emission is preferred, that would be a larger, separate change.

Fixes #61
