### PR TITLE
fix(globals): reject -r 0 to match must-be-positive contract (#71)

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -396,7 +396,7 @@ void Globals::parse_args(int argc, char ** argv) {
             } catch (const std::exception & e) {
                 ERROR("Invalid max RAM provided");
             }
-            if (this->max_ram < 0) {
+            if (this->max_ram <= 0) {
                 ERROR("Max RAM must be positive");
             }
 /**************************************************************************************************/


### PR DESCRIPTION
## Summary

`Globals::parse_args` (`src/globals.cpp`) validated the `-r` / `--max-ram` value with `if (this->max_ram < 0)`, but the error message reads `"Max RAM must be positive"`. Message and logic disagreed: `-r 0` was silently accepted despite the message claiming the value must be positive.

## How `max_ram` is used downstream

I checked whether `0` is a meaningful sentinel (e.g. "unlimited") before choosing a fix. It is not:

- `src/globals.cpp:439` — `ram_steps.push_back(this->max_ram / threads)`; with `max_ram == 0` every RAM step is `0`.
- `src/dist.cpp:790` — `while (total_ram < g.max_ram && thread_step >= 0)`; `total_ram` starts at `0`, so `0 < 0` is false and the "not enough work for all threads" branch schedules **zero** threads, silently dropping superclusters.
- `src/cluster.cpp:607` — `if (mem_gb > g.max_ram)`; with `max_ram == 0` every supercluster "exceeds" RAM and triggers the warning path.

There is no "0 means unlimited" semantics anywhere; `0` simply breaks scheduling.

## Fix

Changed the check to `if (this->max_ram <= 0)` so the validation matches the "must be positive" contract stated in the message. This is the minimal change and the option consistent with actual usage (rather than softening the message, since `0` is not a valid value).

## Compile check

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 globals.cpp -o /tmp/probe_71.o` — clean, no warnings.

Fixes #71
Sub-issue of #45; documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #13.