### PR TITLE
fix(print): align get_ptr_repr invalid-cell width

### DIFF
--- a/src/print.cpp
+++ b/src/print.cpp
@@ -605,7 +605,7 @@ std::string get_ptr_repr(idx4 cell, const std::unordered_map<idx4,idx4> & ptrs) 
         if (cell.qi == prev.qi+1 && cell.ti == prev.ti) { return "  |"; }
         else if (cell.qi == prev.qi && cell.ti == prev.ti+1) { return "  _"; }
         else if (cell.qi == prev.qi+1 && cell.ti == prev.ti+1) { return "  \\"; }
-        else { return "?1"; } // invalid
+        else { return " ?1"; } // invalid
     } else if (cell.qi == 0 && prev.qni < cell.qni) { // different query node, print node id
         std::ostringstream ostr;
         ostr << std::setfill('0') << std::setw(2) << (prev.qni);
@@ -614,7 +614,7 @@ std::string get_ptr_repr(idx4 cell, const std::unordered_map<idx4,idx4> & ptrs) 
         std::ostringstream ostr;
         ostr << std::setfill('0') << std::setw(2) << (prev.tni);
         return "<" + ostr.str();
-    } else { return "?2"; } // invalid
+    } else { return " ?2"; } // invalid
 }
 
 /**


### PR DESCRIPTION
## Root cause

`get_ptr_repr` (src/print.cpp) is a debug helper for `print_graph_ptrs`, which renders the graph-alignment pointer matrix as a fixed-width grid. Every valid cell representation is 3 characters wide (`"  ."`, `"  |"`, `"  _"`, `"  \\"`, `"^NN"`, `"<NN"`), but the two invalid/fallback returns were only 2 characters (`"?1"`, `"?2"`). When an invalid cell was hit, its column was one character narrow, shifting every subsequent column and misaligning the debug grid.

## Fix

Right-align the two invalid strings to 3 characters (`" ?1"`, `" ?2"`) so they occupy the same width as valid cells. No logic or valid-return strings were changed — this is a width-only fix.

## Verification

`g++ -c -g -O1 -Wall -Wextra -std=c++17 print.cpp` compiles clean (exit 0).

Fixes #73

Sub-issue of #45; documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #15.