### PR TITLE
fix(io): null-check fopen in write_params and write_runtime

### DIFF
--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -15,12 +15,16 @@
  * @brief Writes a summary VCF containing all variants annotated with benchmark metrics.
  * @param[in] out_vcf_fn Output VCF filename
  * @note FORMAT fields include: TP/FP/FN decision, credit score, edit distances, phase info, and flip/switch errors
+ * @throws ERROR if the output summary VCF file cannot be opened for writing
  */
 void phaseblockData::write_summary_vcf(std::string out_vcf_fn) {
 
     // VCF header
     if (g.verbosity >= 1) INFO("  Writing summary VCF to '%s'", out_vcf_fn.data());
     FILE* out_vcf = fopen(out_vcf_fn.data(), "w");
+    if (out_vcf == NULL) {
+        ERROR("Failed to open summary VCF file '%s'", out_vcf_fn.data());
+    }
     const std::chrono::time_point<std::chrono::system_clock> now{std::chrono::system_clock::now()};
     time_t tt = std::chrono::system_clock::to_time_t(now);
     tm local_time = *localtime(&tt);
@@ -480,6 +484,7 @@ void phaseblockData::fix_allele_counts() {
 /**
  * @brief Writes allele count error cross-tabulation table to TSV file.
  * @param[in] allele_error_counts 2D array indexed as [allele_count_errtype][vartype]
+ * @throws ERROR if the output genotype error TSV file cannot be opened for writing
  */
 void phaseblockData::write_genotype_error_summary(
         const std::vector< std::vector<int> > & allele_error_counts) {
@@ -487,6 +492,9 @@ void phaseblockData::write_genotype_error_summary(
     FILE* out_genotype_errors = 0;
     if (g.verbosity >= 1) INFO("  Writing genotype error results to '%s'", out_genotype_errors_fn.data());
     out_genotype_errors = fopen(out_genotype_errors_fn.data(), "w");
+    if (out_genotype_errors == NULL) {
+        ERROR("Failed to open genotype error TSV file '%s'", out_genotype_errors_fn.data());
+    }
     fprintf(out_genotype_errors, "VAR_TYPE\tALLELE_COUNT_0_TO_1\tALLELE_COUNT_0_TO_2\tALLELE_COUNT_1_TO_0\tALLELE_COUNT_1_TO_1\tALLELE_COUNT_1_TO_2\tALLELE_COUNT_2_TO_0\tALLELE_COUNT_2_TO_1\tALLELE_COUNT_2_TO_2\n");
     for (int vartype = 0; vartype < VARTYPES; vartype++) {
         fprintf(out_genotype_errors, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
@@ -659,6 +667,7 @@ void phaseblockData::phase()
 /**
  * @brief Writes detected switch and flip error locations and classifications to TSV file.
  * @note Error types: SWITCH_ERR, FLIP, SWITCH_AND_FLIP
+ * @throws ERROR if the output switchflip TSV file cannot be opened for writing
  */
 void phaseblockData::write_switchflips() {
 
@@ -666,6 +675,9 @@ void phaseblockData::write_switchflips() {
     FILE* out_sf = 0;
     if (g.verbosity >= 1) INFO("  Writing switchflip results to '%s'", out_sf_fn.data());
     out_sf = fopen(out_sf_fn.data(), "w");
+    if (out_sf == NULL) {
+        ERROR("Failed to open switchflip TSV file '%s'", out_sf_fn.data());
+    }
     fprintf(out_sf, "CONTIG\tSTART\tSTOP\tSWITCH_TYPE\tVARIANT\tPHASE_BLOCK\n");
 
     // get sizes of each correct phase block (split on flips, not just switch)
@@ -778,6 +790,7 @@ void phaseblockData::write_switchflips() {
  * @param[in] ng50 NG50 of phase blocks without any error breaks
  * @param[in] s_ngc50 NGC50 of phase blocks broken on switch errors
  * @param[in] sf_ngc50 NGC50 of phase blocks broken on switch and flip errors
+ * @throws ERROR if the output phasing summary TSV file cannot be opened for writing
  */
 void phaseblockData::write_phasing_summary(int phase_blocks, int switch_errors,
         int flip_errors, int variants, int ng50, int s_ngc50, int sf_ngc50) {
@@ -786,6 +799,9 @@ void phaseblockData::write_phasing_summary(int phase_blocks, int switch_errors,
     if (g.verbosity >= 1) INFO("  Writing phasing summary to '%s'", 
             out_phasing_summary_fn.data());
     FILE* out_phasing_summary = fopen(out_phasing_summary_fn.data(), "w");
+    if (out_phasing_summary == NULL) {
+        ERROR("Failed to open phasing summary TSV file '%s'", out_phasing_summary_fn.data());
+    }
     fprintf(out_phasing_summary,
             "PHASE_BLOCKS\tSWITCH_ERRORS\tFLIP_ERRORS\tSWITCH_ERROR_RATE\tFLIP_ERROR_RATE\t"
             "NG_50\tSWITCH_NGC50\tSWITCHFLIP_NGC50\n");

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -117,6 +117,7 @@ inline std::string b2s(bool b) { return b ? "true" : "false"; }
 
 /**
  * @brief Writes all pipeline configuration parameters to TSV file.
+ * @throws ERROR if the output parameters TSV file cannot be opened for writing
  */
 void write_params() {
 
@@ -128,7 +129,10 @@ void write_params() {
     // write all params to file
     std::string out_params_fn = g.out_prefix + "parameters.tsv";
     FILE* out_params = fopen(out_params_fn.data(), "w");
-    fprintf(out_params, 
+    if (out_params == NULL) {
+        ERROR("Failed to open parameters TSV file '%s'", out_params_fn.data());
+    }
+    fprintf(out_params,
         "program\t%s\nversion\t%s\nout_prefix\t%s\ncommand\t%s\nreference_fasta\t%s\n"
         "query_vcf\t%s\ntruth_vcf\t%s\nbed_file\t%s\nwrite_outputs\t%s\nfilters\t%s\n"
         "min_var_qual\t%d\nmax_var_qual\t%d\nmax_var_size\t%d\nsv_threshold\t%d\n"

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -262,6 +262,7 @@ void print_wfa_ptrs(
  * @brief Computes precision/recall statistics across all variant types and quality thresholds,
  *        writes full per-threshold results and summary table to TSV files, and prints to console.
  * @param[in] phasedata_ptr Phase block data with evaluated query and truth variants
+ * @throws ERROR if an output precision-recall TSV file cannot be opened for writing
  */
 void write_precision_recall(const std::unique_ptr<phaseblockData> & phasedata_ptr) {
 
@@ -344,6 +345,9 @@ void write_precision_recall(const std::unique_ptr<phaseblockData> & phasedata_pt
         if (g.verbosity >= 1) INFO(" ");
         if (g.verbosity >= 1) INFO("  Writing precision-recall results to '%s'", out_pr_fn.data());
         out_pr = fopen(out_pr_fn.data(), "w");
+        if (out_pr == NULL) {
+            ERROR("Failed to open precision-recall TSV file '%s'", out_pr_fn.data());
+        }
         fprintf(out_pr, "VAR_TYPE\tMIN_QUAL\tPREC\tRECALL\tF1_SCORE\tF1_QSCORE\t"
                 "TRUTH_TOTAL\tTRUTH_TP\tTRUTH_FN\tQUERY_TOTAL\tQUERY_TP\tQUERY_FP\n");
     }
@@ -398,6 +402,9 @@ void write_precision_recall(const std::unique_ptr<phaseblockData> & phasedata_pt
         if (g.verbosity >= 1) 
             INFO("  Writing precision-recall summary to '%s'", out_pr_summ_fn.data());
         out_pr_summ = fopen(out_pr_summ_fn.data(), "w");
+        if (out_pr_summ == NULL) {
+            ERROR("Failed to open precision-recall summary TSV file '%s'", out_pr_summ_fn.data());
+        }
         fprintf(out_pr_summ, "VAR_TYPE\tTHRESHOLD\tMIN_QUAL\tTRUTH_TP\tQUERY_TP\tTRUTH_FN\tQUERY_FP\tPREC\tRECALL\tF1_SCORE\tF1_QSCORE\n");
     }
     INFO(" ");
@@ -475,6 +482,7 @@ void write_precision_recall(const std::unique_ptr<phaseblockData> & phasedata_pt
 /**
  * @brief Writes precision-recall TSV results and prints console summary.
  * @param[in] phasedata_ptr Phase block data with variant evaluation results
+ * @throws ERROR if an output results TSV file cannot be opened for writing
  */
 void write_results(std::unique_ptr<phaseblockData> & phasedata_ptr) {
     if (g.verbosity >= 1) INFO(" ");
@@ -489,6 +497,9 @@ void write_results(std::unique_ptr<phaseblockData> & phasedata_ptr) {
         // print phasing information
         std::string out_phaseblocks_fn = g.out_prefix + "phase-blocks.tsv";
         FILE* out_phaseblocks = fopen(out_phaseblocks_fn.data(), "w");
+        if (out_phaseblocks == NULL) {
+            ERROR("Failed to open phase-blocks TSV file '%s'", out_phaseblocks_fn.data());
+        }
         if (g.verbosity >= 1) INFO("  Writing phasing results to '%s'", out_phaseblocks_fn.data());
         fprintf(out_phaseblocks, "CONTIG\tPHASE_BLOCK\tSTART\tSTOP\tSIZE\tVARIANTS\tFLIP_ERRORS\tSWITCH_ERRORS\n");
         for (const std::string & ctg : phasedata_ptr->contigs) {
@@ -518,6 +529,9 @@ void write_results(std::unique_ptr<phaseblockData> & phasedata_ptr) {
         std::string out_query_fn = g.out_prefix + "query.tsv";
         if (g.verbosity >= 1) INFO("  Writing query variant results to '%s'", out_query_fn.data());
         FILE* out_query = fopen(out_query_fn.data(), "w");
+        if (out_query == NULL) {
+            ERROR("Failed to open query variant TSV file '%s'", out_query_fn.data());
+        }
         fprintf(out_query, "CONTIG\tPOS\tHAP\tREF\tALT\tQUAL\tTYPE\tERRTYPE"
                 "\tCREDIT\tSUPERCLUSTER\tSYNC_GROUP\tREF_DIST\tQUERY_DIST\tLOCATION\n");
         for (const std::string & ctg : phasedata_ptr->contigs) {
@@ -556,6 +570,9 @@ void write_results(std::unique_ptr<phaseblockData> & phasedata_ptr) {
         std::string out_truth_fn = g.out_prefix + "truth.tsv";
         if (g.verbosity >= 1) INFO("  Writing truth variant results to '%s'", out_truth_fn.data());
         FILE* out_truth = fopen(out_truth_fn.data(), "w");
+        if (out_truth == NULL) {
+            ERROR("Failed to open truth variant TSV file '%s'", out_truth_fn.data());
+        }
         fprintf(out_truth, "CONTIG\tPOS\tHAP\tREF\tALT\tQUAL\tTYPE\tERRTYPE"
                 "\tCREDIT\tSUPERCLUSTER\tSYNC_GROUP\tREF_DIST\tQUERY_DIST\tLOCATION\n");
         for (const std::string & ctg : phasedata_ptr->contigs) {

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -62,11 +62,15 @@ std::string timer::get_name() {
 
 /**
  * @brief Writes all pipeline stage timer names and elapsed times to TSV file.
+ * @throws ERROR if the output runtime TSV file cannot be opened for writing
  */
 void write_runtime() {
     std::string runtimes_fn = g.out_prefix + "runtime.tsv";
     if (g.verbosity >= 1) INFO("  Writing stage runtimes '%s'", runtimes_fn.data());
     FILE* out_runtimes = fopen(runtimes_fn.data(), "w");
+    if (out_runtimes == NULL) {
+        ERROR("Failed to open runtime TSV file '%s'", runtimes_fn.data());
+    }
     for (int i = 0; i <= TIME_TOTAL; i++) {
         fprintf(out_runtimes, "%s\t%lf\n", g.timers[i].get_name().data(), g.timers[i].total());
     }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -202,11 +202,15 @@ int ctgVariants::set_allele_errtype(int vi) {
 /**
  * @brief Writes all parsed variants to a phased VCF file.
  * @param[in] out_vcf_fn Output VCF filename
+ * @throws ERROR if the output VCF file cannot be opened for writing
  */
 void variantData::write_vcf(std::string out_vcf_fn) {
 
     // VCF header
     FILE* out_vcf = fopen(out_vcf_fn.data(), "w");
+    if (out_vcf == NULL) {
+        ERROR("Failed to open VCF file '%s'", out_vcf_fn.data());
+    }
     const std::chrono::time_point now{std::chrono::system_clock::now()};
     time_t tt = std::chrono::system_clock::to_time_t(now);
     tm local_time = *localtime(&tt);


### PR DESCRIPTION
## Root cause

Many functions `fopen(...)` an output file under `g.out_prefix` and immediately `fprintf` into the returned `FILE*` without checking it. If the prefix is unwritable (missing directory, permissions, etc.), `fopen` returns `NULL` and the subsequent `fprintf` dereferences a NULL `FILE*`, crashing the process. Only the read-mode opens (`bed.cpp`, `globals.cpp`) were guarded.

## Fix

Added a NULL guard after each unguarded write-mode `fopen`, matching the existing `Failed to open ...` `ERROR()` style used elsewhere (`src/globals.cpp`, `src/bed.cpp`). All ten write-mode sites are now guarded:

- `print.cpp`: `write_params`, `write_precision_recall` (`out_pr`, `out_pr_summ`), `write_results` (`out_phaseblocks`, `out_query`, `out_truth`)
- `timer.cpp`: `write_runtime`
- `phase.cpp`: `write_summary_vcf`, `write_genotype_error_summary`, `write_switchflips`, `write_phasing_summary`
- `variant.cpp`: `write_vcf`

Each affected function's Doxygen comment gains a `@throws ERROR` line per repo conventions. Nothing about the file contents written changes.

## Compile results

`print.cpp`, `timer.cpp`, `phase.cpp`, and `variant.cpp` all compile clean:

```
g++ -c -g -O1 -Wall -Wextra -std=c++17 phase.cpp    -> OK
g++ -c -g -O1 -Wall -Wextra -std=c++17 print.cpp    -> OK
g++ -c -g -O1 -Wall -Wextra -std=c++17 variant.cpp  -> OK
g++ -c -g -O1 -Wall -Wextra -std=c++17 timer.cpp    -> OK
```

Fixes #74
Sub-issue of #45 (documented in `docs/D2_vcfdist-v3-unit-tests.md` §6 defect #16).
