### PR TITLE
fix(globals): document -v flag overload in parse_args (#70)

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -45,6 +45,12 @@ std::vector<std::string> vartype_strs = {"SNP", "INDEL", "SV", "ALL"};
  * @note Required args: query.vcf, truth.vcf, ref.fasta (must be first 3). Optional flag groups:
  *       input/output (-b, -v, -p, -n), variant filtering (-f, -l, -sv, -q, -mq),
  *       clustering (-s), precision-recall (-ct, -md), resources (-t, -r), misc (-h, -ci).
+ * @note The '-v' short flag is intentionally overloaded and disambiguated by argument count:
+ *       when the required args are absent (argc < 4) it aliases '--version' (print version and
+ *       exit); when the required args are present (argc >= 4) it aliases '--verbosity' (expects a
+ *       trailing 0/1/2). The two meanings never collide at runtime because they live in mutually
+ *       exclusive argc regimes, but the overload is confusing and both spellings are documented in
+ *       print_usage(). See issue #70 (sub-issue of #45, D2 defect #12) for a proposed flag change.
  * @throws Errors on invalid file paths, out-of-range parameters, or format errors.
  */
 void Globals::parse_args(int argc, char ** argv) {
@@ -61,6 +67,9 @@ void Globals::parse_args(int argc, char ** argv) {
                 print_help = true;
             } else if (std::string(argv[i]) == "-v" ||
                     std::string(argv[i]) == "--version") {
+                // NOTE (#70): here '-v' means '--version'. In the main option loop below (reached
+                // only when argc >= 4) the same '-v' short flag instead aliases '--verbosity'.
+                // The overload is intentional and argc-gated; see the parse_args @note above.
                 i++;
                 this->print_version();
             } else if (std::string(argv[i]) == "-ci" || 
@@ -80,8 +89,11 @@ void Globals::parse_args(int argc, char ** argv) {
     }
 
     // parse verbosity first
+    // NOTE (#70): here '-v' means '--verbosity' (reached only when argc >= 4). In the argc < 4
+    // pre-check above the same '-v' short flag instead aliases '--version'. The overload is
+    // intentional and argc-gated; see the parse_args @note above.
     for (int i = 0; i+1 < argc; i++) {
-        if (std::string(argv[i]) == "-v" || 
+        if (std::string(argv[i]) == "-v" ||
                 std::string(argv[i]) == "--verbosity") {
             i++;
             if (i == argc) {


### PR DESCRIPTION
## Summary

Fixes the latent `-v` flag overload in `Globals::parse_args` (`src/globals.cpp`).

## The overload

`-v` has two different meanings depending on how many arguments were supplied:

- **Pre-check block (`argc < 4`, required args absent):** `-v` / `--version` prints the version and exits.
- **Main option loop (`argc >= 4`, required args present):** the "parse verbosity first" loop treats `-v` / `--verbosity` as verbosity, expecting a trailing numeric `0`/`1`/`2`.

`print_usage()` documents `-v` under **both** spellings — once as `-v, --verbosity <INTEGER>` (Inputs/Outputs) and once as `-v, --version` (Miscellaneous) — so the overload is baked into the documented interface.

The two meanings never actually collide at runtime, because they live in mutually exclusive argc regimes (version requires the mandatory args to be absent; verbosity requires them present). It is nonetheless confusing and easy to misread.

## Options considered

- **(a) Keep behavior, document it clearly.** Zero risk of breaking existing invocations; the overload becomes intentional and discoverable. Does not remove the confusion, only labels it.
- **(b) Disambiguate the flags** — e.g. reserve `-v`/`--version` for version only and require `--verbosity` (or a new short flag such as `-V`) for verbosity. This is the cleaner long-term fix but **changes a documented, user-facing flag** and would break existing scripts/invocations that pass `-v <N>` for verbosity.

## Chosen change (option a)

Per the conservative, minimal-disruption guidance, this PR takes option (a):

- Added an `@note` to the `parse_args` Doxygen header explaining the argc-gated overload.
- Added inline `NOTE (#70)` comments at both the `--version` pre-check branch and the `--verbosity` main-loop branch, each pointing at the other and at the header note.

No flag, help text, or runtime behavior was changed — every existing invocation keeps working.

## CLI decision for maintainer review

Option (b) — disambiguating the flags — is a user-facing interface change and should not be made unilaterally. **Please advise** whether you want to:

1. Leave `-v` overloaded (this PR), or
2. Reserve `-v`/`--version` for version and move verbosity to `--verbosity` only (dropping the `-v` alias for verbosity), or
3. Move version to a new flag (e.g. `-V`/`--version`) and keep `-v` for verbosity.

Any of (2)/(3) would also require updating `print_usage()`; happy to follow up in a separate PR once a direction is chosen.

## Verification

`cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 globals.cpp -o /tmp/probe_70.o` — compiles clean (exit 0, no warnings).

Fixes #70. Sub-issue of #45; documented in docs/D2_vcfdist-v3-unit-tests.md §6 defect #12.
