### PR TITLE
fix(print): reconcile qscore clamp with documentation (#72)

### DIFF
--- a/src/print.cpp
+++ b/src/print.cpp
@@ -104,9 +104,14 @@ std::string PURPLE(const std::string & str) { return "\033[35m" + str + "\033[0m
 /**************************************************************************************************/
 
 /**
- * @brief Converts error probability to Phred quality score.
- * @param[in] p_error Error probability in (0, 1]
- * @return Quality score in [0, 100], clamped at 100 for high confidence
+ * @brief Converts an error probability to a Phred-scaled quality score.
+ *
+ * Used for the F1-Qscore accuracy metric (called as `qscore(1 - f1_score)`). This is a
+ * benchmarking summary statistic and is intentionally capped at 100 — a value distinct from the
+ * per-variant quality cap `g.max_qual` (default 60) applied to VCF QUAL values in
+ * `var_quals`/`gt_quals`. The two caps govern unrelated quantities and are not meant to match.
+ * @param[in] p_error Error probability; values <= 0 map to 100 (via +inf), values >= 1 map to 0
+ * @return Phred quality score, clamped to the range [0, 100]
  * @note Formula: Q = -10 * log10(p_error)
  */
 float qscore(double p_error) {


### PR DESCRIPTION
## Summary

Reconciles the `qscore()` doc-comment with its (deliberate) 100.0 clamp. **Documentation-only change; no behavior change** — the code was already correct.

Fixes #72. Sub-issue of #45; documented in `docs/deliverables/D2_vcfdist-v3-unit-tests.md` §6 defect #14.

## Investigation

**Callers** — in v3, `qscore()` is used *exclusively* for the F1-Qscore accuracy metric, always as `qscore(1 - f1_score)`:
- `src/print.cpp:378` — per-threshold `precision-recall.tsv` row
- `src/print.cpp:444` — `PRECISION-RECALL SUMMARY` console output
- `src/print.cpp:459` — `precision-recall-summary.tsv` row

**Related quality bounds** (a *different* quantity):
- `src/globals.h:37` — `int max_qual = 60; ///< Maximum variant quality score (variants above are clamped)`
- `src/variant.h:75-76` — `gt_quals` / `var_quals` documented `(0-60)` (the VCF QUAL field)

These `60` bounds govern **per-variant quality** (the VCF `QUAL` column and the PR-curve threshold binning `for qual = min_qual..max_qual`). They are unrelated to the F1-Qscore, which is a benchmarking summary statistic derived from the F1 score.

## Intended cap and evidence

**Intended cap: 100 (deliberate).** The code is correct as written.

- The F1-Qscore is a distinct accuracy metric from per-variant quality; the `max_qual=60` cap does not apply to it. A very accurate caller with F1 error `1e-7` legitimately yields Q70 — capping the metric at 60 would understate top callers.
- The `100.0` clamp has been present in this function since it was first introduced (commit `83abb14`); it is not a v3 regression.
- The D2 test spec **deliberately pins 100** and locks it: `qs-clamp-high` (`1e-11`→100), `qs-p-0` (`log10(0)`→+inf→clamped 100), and states *"Note the code clamps to 100.0 (not 60) — the test locks that."* (D2 §5). Defect #14 asks that the doc-comment and code be **reconciled**, not that behavior change.

The "D1/legacy convention references a 60 cap" refers to the per-variant quality cap (`max_qual`), a separate quantity — not the F1-Qscore.

## What changed

`src/print.cpp` — the `qscore()` `.cpp` doc-comment only. No code/behavior change.

- Explains that the 100 cap is intentional and distinct from the per-variant `g.max_qual` (default 60) cap on `var_quals`/`gt_quals`, so future readers do not mistake it for the variant-quality bound.
- Documents the actual boundary behavior the tests exercise: `p_error <= 0` → 100 (via +inf), `p_error >= 1` → 0.
- `@return` (not `@returns`) per repo Doxygen conventions.

The `src/print.h` brief (`@brief Converts error probability to Phred quality score.`) makes no claim about the cap and needed no change.

## Compile verification

```
cd src && g++ -c -g -O1 -Wall -Wextra -std=c++17 print.cpp -o /tmp/probe_72.o
# EXIT: 0 — clean, no warnings
```

## Maintainer note

The cap remains **100** and behavior is unchanged (aligned with the D2 test lock). If the maintainer intends the F1-Qscore to instead be capped at `g.max_qual`/60, that would be a behavior change requiring a corresponding code change and test update — flagging in case the "60 convention" was meant to apply here.
